### PR TITLE
Terraform 및 GitHub Actions 관련

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,67 @@
+name: Deploy FE to AWS
+
+on:
+#  push:
+#    branches:
+#      - dev
+  workflow_dispatch:
+
+
+
+permissions:
+  # oidc 인증용
+  id-token: write
+  # 체크아웃용
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifact
+          path: ./dist
+
+  deploy:
+    name: Deploy to AWS
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifact
+          path: .
+
+      - name: Upload to S3
+        run: |
+          aws s3 sync . s3://${{ secrets.S3_BUCKET_NAME }} --delete
+
+      - name: Invalidate Cloudfront cache
+        # Cloudfront cache 무효화 -> 즉시 최신 버전 볼 수 있게 함
+        run: |
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -26,9 +26,9 @@ locals {
 module "s3" {
   source = "./modules/s3"
 
-  bucket_name = var.bucket_name
+  bucket_name     = var.bucket_name
   log_bucket_name = var.log_bucket_name
-  prefix      = var.prefix
+  prefix          = var.prefix
 }
 
 module "acm" {
@@ -41,8 +41,8 @@ module "acm" {
   domain_name               = var.domain_name
   subject_alternative_names = ["*.${var.domain_name}"]
   # DNS 방식으로 도메인 검증
-  validation_method         = "DNS"
-  prefix                    = var.prefix
+  validation_method = "DNS"
+  prefix            = var.prefix
 }
 
 module "cloudfront" {
@@ -54,7 +54,7 @@ module "cloudfront" {
   bucket_regional_domain_name = module.s3.bucket_regional_domain_name
   domain_names                = [var.domain_name, "www.${var.domain_name}"]
   acm_certificate_arn         = module.acm.certificate_arn
-  log_bucket_domain_name = module.s3.log_bucket_domain_name
+  log_bucket_domain_name      = module.s3.log_bucket_domain_name
 }
 
 module "route53" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,91 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+# Default provider
+provider "aws" {
+  region = var.aws_region
+}
+
+# ACM cert provider (Cloudfront = us-east-1 인증서만 사용 가능)
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+}
+
+locals {
+  # acm 인증서에 사용될 san 목록 => 와일드카드로
+  acm_sans = ["*.${var.domain_name}"]
+}
+
+module "s3" {
+  source = "./modules/s3"
+
+  bucket_name = var.bucket_name
+  log_bucket_name = var.log_bucket_name
+  prefix      = var.prefix
+}
+
+module "acm" {
+  source = "./modules/acm"
+
+  providers = {
+    aws.us-east-1 = aws.us-east-1
+  }
+
+  domain_name               = var.domain_name
+  subject_alternative_names = ["*.${var.domain_name}"]
+  # DNS 방식으로 도메인 검증
+  validation_method         = "DNS"
+  prefix                    = var.prefix
+}
+
+module "cloudfront" {
+  source = "./modules/cloudfront"
+
+  prefix                      = var.prefix
+  bucket_id                   = module.s3.bucket_id
+  bucket_arn                  = module.s3.bucket_arn
+  bucket_regional_domain_name = module.s3.bucket_regional_domain_name
+  domain_names                = [var.domain_name, "www.${var.domain_name}"]
+  acm_certificate_arn         = module.acm.certificate_arn
+  log_bucket_domain_name = module.s3.log_bucket_domain_name
+}
+
+module "route53" {
+  source = "./modules/route53"
+
+  providers = {
+    aws.us-east-1 = aws.us-east-1
+  }
+
+  domain_name     = var.domain_name
+  subdomain_names = ["", "www"]
+  # acm 인증이 필요한 전체 도메인 목록을 전달
+  acm_domains_for_validation                = concat([var.domain_name], local.acm_sans)
+  acm_certificate_domain_validation_options = module.acm.domain_validation_options
+  acm_certificate_arn                       = module.acm.certificate_arn
+  cloudfront_distribution_domain_name       = module.cloudfront.distribution_domain_name
+  cloudfront_distribution_hosted_zone_id    = module.cloudfront.distribution_hosted_zone_id
+
+  depends_on = [module.acm]
+}
+
+module "github_oidc" {
+  source = "./modules/oidc"
+
+  prefix               = var.prefix
+  allowed_repositories = var.github_allowed_repo
+  bucket_arn           = module.s3.bucket_arn
+  distribution_arn     = module.cloudfront.distribution_arn
+}
+
+# S3 퍼블릭 전면 차단
+# CloudFront origin access control(OAC)통해서만 (Cloudfront캐시 계층 경유 요청만 허용) 버킷 내 객체 읽을 수 있도록 s3 버킷 정책
+# Cloudfront 생성시 OAC 생성 필요 (S3 에 서명기반 요청) → OAC ID 를 s3 정책/CloudFront origin 설정에 연결하면 Cloudfornt 만 s3에 접근 가능 == oidc 생성 필요
+# OIDC로 GitHub actions에서 s3로 배포 가능 (s3 퍼블릭 만 차단 → oidc로 자격 증명)

--- a/terraform/modules/acm/main.tf
+++ b/terraform/modules/acm/main.tf
@@ -18,7 +18,7 @@ resource "aws_acm_certificate" "fe" {
   # 추가 도메인 목록
   subject_alternative_names = var.subject_alternative_names
   # 도메인 소유권 검증 방식 (DNS or EMAIL)
-  validation_method         = var.validation_method
+  validation_method = var.validation_method
 
   lifecycle {
     # 갱신시 새 인증서 생성후 기존 인증서 파괴

--- a/terraform/modules/acm/main.tf
+++ b/terraform/modules/acm/main.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+      # 별도 리전용 프로바이더 지정하도록 alias 설정
+      configuration_aliases = [aws.us-east-1]
+    }
+  }
+}
+
+# ACM cert 생성 (cloudfront acm cert = us-east-1에서만 생성가능)
+resource "aws_acm_certificate" "fe" {
+  provider = aws.us-east-1
+
+  # 기본 도메인
+  domain_name = var.domain_name
+  # 추가 도메인 목록
+  subject_alternative_names = var.subject_alternative_names
+  # 도메인 소유권 검증 방식 (DNS or EMAIL)
+  validation_method         = var.validation_method
+
+  lifecycle {
+    # 갱신시 새 인증서 생성후 기존 인증서 파괴
+    create_before_destroy = true
+  }
+
+  tags = {
+    "Name" = "${var.prefix}-certificate"
+  }
+}
+

--- a/terraform/modules/acm/outputs.tf
+++ b/terraform/modules/acm/outputs.tf
@@ -1,0 +1,19 @@
+output "certificate_arn" {
+  description = "ACM cert ARN"
+  value       = aws_acm_certificate.fe.arn
+}
+
+output "certificate_id" {
+  description = "ACM cert ID"
+  value       = aws_acm_certificate.fe.id
+}
+
+output "certificate_status" {
+  description = "ACM cert status"
+  value       = aws_acm_certificate.fe.status
+}
+
+output "domain_validation_options" {
+  description = "Domain validation option"
+  value       = aws_acm_certificate.fe.domain_validation_options
+}

--- a/terraform/modules/acm/variables.tf
+++ b/terraform/modules/acm/variables.tf
@@ -1,0 +1,21 @@
+variable "prefix" {
+  description = "Prefix for ACM module"
+  type        = string
+}
+
+variable "domain_name" {
+  description = "Domain name"
+  type        = string
+}
+
+variable "subject_alternative_names" {
+  description = "Subject alternative names"
+  type        = list(string)
+  default     = []
+}
+
+variable "validation_method" {
+  description = "Cert validation method (DNS or EMAIL)"
+  type        = string
+  default     = "DNS"
+}

--- a/terraform/modules/cloudfront/main.tf
+++ b/terraform/modules/cloudfront/main.tf
@@ -26,8 +26,8 @@ resource "aws_cloudfront_distribution" "fe" {
 
   logging_config {
     include_cookies = false
-    bucket = var.log_bucket_domain_name
-    prefix = "${var.prefix}/"
+    bucket          = var.log_bucket_domain_name
+    prefix          = "${var.prefix}/"
   }
 
   # 기본 캐싱 정책

--- a/terraform/modules/cloudfront/main.tf
+++ b/terraform/modules/cloudfront/main.tf
@@ -1,0 +1,110 @@
+# 클라우드프론트 Origin access control 생성
+resource "aws_cloudfront_origin_access_control" "fe" {
+  name                              = "${var.prefix}-oac"
+  description                       = "OAC for ${var.prefix}-s3"
+  origin_access_control_origin_type = "s3"
+  # 요청마다 서명
+  signing_behavior = "always"
+  signing_protocol = "sigv4"
+}
+
+#CF 생성 및 설정
+resource "aws_cloudfront_distribution" "fe" {
+  # origin = s3
+  origin {
+    domain_name              = var.bucket_regional_domain_name
+    origin_access_control_id = aws_cloudfront_origin_access_control.fe.id
+    origin_id                = var.bucket_id
+  }
+
+  enabled         = true
+  is_ipv6_enabled = true
+  comment         = "${var.prefix}-cf-distribution"
+  # 루트 요청시 반환 기본 객체
+  default_root_object = "index.html"
+  aliases             = var.domain_names
+
+  logging_config {
+    include_cookies = false
+    bucket = var.log_bucket_domain_name
+    prefix = "${var.prefix}/"
+  }
+
+  # 기본 캐싱 정책
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = var.bucket_id
+
+    forwarded_values {
+      # query 스트링 포워딩 안함
+      query_string = false
+      # CORS 처리 위해 Origin, Access-Control-* 헤더만 전달
+      headers = ["Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers"]
+
+      cookies {
+        # 쿠키 전달 안함
+        forward = "none"
+      }
+    }
+
+    # https 리다이렉트
+    viewer_protocol_policy = "redirect-to-https"
+    # 캐시 유효기간 초
+    min_ttl     = 0
+    default_ttl = 3600
+    max_ttl     = 86400
+    compress    = true
+  }
+
+  # 접속 국가 제한
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  # SSL TLS 인증성
+  viewer_certificate {
+    cloudfront_default_certificate = var.acm_certificate_arn == "" ? true : false
+    acm_certificate_arn            = var.acm_certificate_arn != "" ? var.acm_certificate_arn : null
+    ssl_support_method             = var.acm_certificate_arn != "" ? "sni-only" : null
+    minimum_protocol_version       = var.acm_certificate_arn != "" ? "TLSv1.2_2021" : null
+
+  }
+
+  tags = {
+    "Name" = "${var.prefix}-cf-distribution"
+  }
+}
+
+# CloudFront Origin access control 통해서만 버킷 객체 읽을 수 있도록 정책 설정
+# S3 버킷 정책 - Cloudfront 배포 정보 필요하므로 순환참조 문제 해결 위해 cloudfront모듈에서 선언
+# Cloudfront -> S3 필요 (aws_cloudfront_distribution에서 원본으로 사용할 s3 정보 필요), S3 버킷 정책 -> Cloudfront 필요 (특정 cloudfront에서 오는 요청만 허용하도록 정책하기 위해서)
+resource "aws_s3_bucket_policy" "fe" {
+  bucket = var.bucket_id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        # CloudFront에 권한 부여
+        Principal = {
+          Service = "cloudfront.amazonaws.com"
+        }
+        # Resource의 S3 getObject 권한
+        Action   = "s3:GetObject"
+        Resource = "${var.bucket_arn}/*"
+
+        # "AWS:SourceArn"의 값이 var.cloudfront_distribution_arn와 똑같을 때만
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.fe.arn
+          }
+        }
+      }
+    ]
+    }
+  )
+}

--- a/terraform/modules/cloudfront/outputs.tf
+++ b/terraform/modules/cloudfront/outputs.tf
@@ -1,0 +1,19 @@
+output "distribution_id" {
+  description = "CloudFront distribution ID"
+  value       = aws_cloudfront_distribution.fe.id
+}
+
+output "distribution_arn" {
+  description = "CloudFront distribution ARN"
+  value       = aws_cloudfront_distribution.fe.arn
+}
+
+output "distribution_domain_name" {
+  description = "CloudFront distribution domain name"
+  value       = aws_cloudfront_distribution.fe.domain_name
+}
+
+output "distribution_hosted_zone_id" {
+  description = "CloudFront distribution hosting zone ID"
+  value       = aws_cloudfront_distribution.fe.hosted_zone_id
+}

--- a/terraform/modules/cloudfront/variables.tf
+++ b/terraform/modules/cloudfront/variables.tf
@@ -31,6 +31,6 @@ variable "domain_names" {
 
 variable "log_bucket_domain_name" {
   description = "S3 bucket name for log"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }

--- a/terraform/modules/cloudfront/variables.tf
+++ b/terraform/modules/cloudfront/variables.tf
@@ -1,0 +1,36 @@
+variable "prefix" {
+  description = "Prefix for CloudFront module"
+  type        = string
+}
+
+variable "bucket_regional_domain_name" {
+  description = "S3 bucket region domain name"
+  type        = string
+}
+
+variable "bucket_id" {
+  description = "S3 bucket ID"
+  type        = string
+}
+
+variable "bucket_arn" {
+  description = "S3 bucket ARN"
+  type        = string
+}
+
+variable "acm_certificate_arn" {
+  description = "ACM certificate ARN"
+  type        = string
+  default     = ""
+}
+
+variable "domain_names" {
+  description = "Domain CNAME list"
+  type        = list(string)
+}
+
+variable "log_bucket_domain_name" {
+  description = "S3 bucket name for log"
+  type = string
+  default = ""
+}

--- a/terraform/modules/oidc/main.tf
+++ b/terraform/modules/oidc/main.tf
@@ -1,0 +1,88 @@
+# github에서 AWS에 oidc 방식으로 연동할 수 있도록 하는 oidc provider 생성
+resource "aws_iam_openid_connect_provider" "github" {
+  # Github actions가 토큰 발급하는 oidc endpoint url
+  url = "https://token.actions.githubusercontent.com"
+
+  # 발급받은 토큰을 aws sts통해 교환시 허용할 클라이언트 id
+  client_id_list = ["sts.amazonaws.com"]
+
+  # github oidc 제공자의 tls 인증서 thumbprint -> aws가 provider ep와 안전하게 통신했음 검증
+  thumbprint_list = var.thumbprint_list
+
+  tags = {
+    "Name" = "${var.prefix}-github-oidc"
+  }
+}
+
+# github actions가 aws 리소스 접근시 사용할 iam role
+resource "aws_iam_role" "github" {
+  name = "${var.prefix}-github-actions-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          # 만든 oidc provider로 부터 발급된 토큰만
+          Federated = aws_iam_openid_connect_provider.github.arn
+        }
+        # oidc 토큰으로 role 획득하는 sts api 호출
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            # 토큰 audience 가 aws sts용인지 검증
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            # 토큰 subject가 특정 레포에서 발급된 것만 허용
+            "token.actions.githubusercontent.com:sub" = [
+              for repo in var.allowed_repositories : "repo:${repo}:*"
+            ]
+          }
+        }
+      }
+    ]
+  })
+
+  tags = {
+    "Name" = "${var.prefix}-github-actions-role"
+  }
+}
+
+# 생성한 iam role에 policy 부여
+resource "aws_iam_role_policy" "github" {
+  name = "${var.prefix}-github-actions-role-policy"
+
+  role = aws_iam_role.github.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        # 버킷자체, 버킷내 모든 객체에 대한 crud
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:DeleteObject",
+          "s3:PutObjectAcl"
+        ]
+        Resource = [
+          var.bucket_arn, "${var.bucket_arn}/*"
+        ]
+      },
+      {
+        # cloudfront 캐시 무효화
+        Effect = "Allow"
+        Action = [
+          "cloudfront:CreateInvalidation"
+        ]
+        Resource = [
+          var.distribution_arn
+        ]
+      }
+    ]
+  })
+}

--- a/terraform/modules/oidc/outputs.tf
+++ b/terraform/modules/oidc/outputs.tf
@@ -1,0 +1,15 @@
+output "role_arn" {
+  description = "Github IAM Role ARN"
+  value       = aws_iam_role.github.arn
+}
+
+output "role_name" {
+  description = "Github IAM ROle name"
+  value       = aws_iam_role.github.name
+}
+
+output "oidc_provider_arn" {
+  description = "Github OIDC Provider ARN"
+  value       = aws_iam_openid_connect_provider.github.arn
+}
+

--- a/terraform/modules/oidc/variables.tf
+++ b/terraform/modules/oidc/variables.tf
@@ -1,0 +1,27 @@
+variable "thumbprint_list" {
+  description = "Github OIDC thumbprint list"
+  type        = list(string)
+  default = [
+    "6938fd4d98bab03faadb97b34396831e3780aea1"
+  ]
+}
+
+variable "prefix" {
+  description = "Prefix for OIDC module"
+  type        = string
+}
+
+variable "allowed_repositories" {
+  description = "Allowed github repo list (username/repo-name)"
+  type        = list(string)
+}
+
+variable "bucket_arn" {
+  description = "Allowed S3 bucket ARN"
+  type        = string
+}
+
+variable "distribution_arn" {
+  description = "Allowed CloudFront distribution ARN for invalidation"
+  type        = string
+}

--- a/terraform/modules/route53/main.tf
+++ b/terraform/modules/route53/main.tf
@@ -1,0 +1,69 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+      # 별도 리전용 프로바이더 지정하도록 alias 설정
+      configuration_aliases = [aws.us-east-1]
+    }
+  }
+}
+
+# 이미 존재하는 hosted zone 조회
+data "aws_route53_zone" "main" {
+  name = var.domain_name
+}
+
+# ACM validation dns records 생성
+resource "aws_route53_record" "cert_validation" {
+  for_each = { for idx, domain in var.acm_domains_for_validation : idx => domain }
+
+  name            = var.acm_certificate_domain_validation_options[each.key].resource_record_name
+  type            = var.acm_certificate_domain_validation_options[each.key].resource_record_type
+  records         = [var.acm_certificate_domain_validation_options[each.key].resource_record_value]
+  ttl             = 60
+  zone_id         = data.aws_route53_zone.main.zone_id
+  allow_overwrite = true
+}
+
+# ACM cert validation
+# acm 인증서 유효성 검증 - Route53에서 만든 dns 레코드로 유효성 검증해야하므로 순환참조 문제 해결 위해 route53모듈에서 선언
+# acm 모듈이 인증서 생성(aws_acm_certificate) -> route53이 acm 모듈의 정보 받아 dns 레코드 생성(aws_route53_record) -> 만든 dns 레코드 기반으로 acm 인증서 유효성 검증 (aws_acm_certificate_validation)
+resource "aws_acm_certificate_validation" "fe" {
+  provider = aws.us-east-1
+
+  certificate_arn = var.acm_certificate_arn
+  # dns 검증용 레코드 fqdn(fully qualified domain name) 목록
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+
+  timeouts {
+    # 인증서 검증 완료까지 대기 시간
+    create = "30m"
+  }
+}
+
+# a record 생성 (ipv4)
+resource "aws_route53_record" "frontend_a" {
+  for_each = toset(var.subdomain_names)
+  zone_id  = data.aws_route53_zone.main.zone_id
+  name     = each.value == "" ? var.domain_name : "${each.value}.${var.domain_name}"
+  type     = "A"
+  alias {
+    name                   = var.cloudfront_distribution_domain_name
+    zone_id                = var.cloudfront_distribution_hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# aaaa record 생성 (ipv6)
+resource "aws_route53_record" "frontend_aaaa" {
+  for_each = toset(var.subdomain_names)
+  zone_id  = data.aws_route53_zone.main.zone_id
+  name     = each.value == "" ? var.domain_name : "${each.value}.${var.domain_name}"
+  type     = "AAAA"
+  alias {
+    name                   = var.cloudfront_distribution_domain_name
+    zone_id                = var.cloudfront_distribution_hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/terraform/modules/route53/outputs.tf
+++ b/terraform/modules/route53/outputs.tf
@@ -1,0 +1,11 @@
+output "zone_id" {
+  description = "Route53 hosting zone ID"
+  value       = data.aws_route53_zone.main.zone_id
+}
+
+output "name_servers" {
+  description = "Route53 nameserver"
+  value       = data.aws_route53_zone.main.name_servers
+}
+
+

--- a/terraform/modules/route53/variables.tf
+++ b/terraform/modules/route53/variables.tf
@@ -1,0 +1,41 @@
+variable "domain_name" {
+  description = "Route domain name"
+  type        = string
+}
+
+variable "subdomain_names" {
+  description = "Subdomain list"
+  type        = list(string)
+}
+
+variable "acm_domains_for_validation" {
+  description = "Domain list for ACM validation"
+  type        = list(string)
+  default     = []
+}
+
+variable "acm_certificate_domain_validation_options" {
+  description = "ACM domain validation"
+  type = list(object({
+    domain_name           = string
+    resource_record_name  = string
+    resource_record_type  = string
+    resource_record_value = string
+  }))
+  default = []
+}
+
+variable "acm_certificate_arn" {
+  description = "ACM certificate ARN for validation"
+  type        = string
+}
+
+variable "cloudfront_distribution_domain_name" {
+  description = "Cloudfront distribution domain name for alias record"
+  type        = string
+}
+
+variable "cloudfront_distribution_hosted_zone_id" {
+  description = "Cloudfront distribution hosted zone ID for alias record"
+  type        = string
+}

--- a/terraform/modules/s3/main.tf
+++ b/terraform/modules/s3/main.tf
@@ -1,0 +1,81 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+# content bucket 생성
+resource "aws_s3_bucket" "fe" {
+  bucket = var.bucket_name
+
+  tags = {
+    "Name" = "${var.prefix}-bucket"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "fe" {
+  bucket = aws_s3_bucket.fe.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# 퍼블릭 엑세스 전면 차단
+resource "aws_s3_bucket_public_access_block" "fe" {
+  bucket = aws_s3_bucket.fe.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# 모든 객체 서버사이드 암호화 / 별도 키 관리 필요 없는 s3 관리형 키로 객체 암호화
+resource "aws_s3_bucket_server_side_encryption_configuration" "fe" {
+  bucket = aws_s3_bucket.fe.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# log bucket 생성
+resource "aws_s3_bucket" "fe_log" {
+  bucket = var.log_bucket_name
+
+  tags = {
+    "Name" = "${var.prefix}-log-bucket"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "fe_log" {
+  bucket = aws_s3_bucket.fe_log.id
+
+  # 버킷 acl 활성화
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = true
+}
+
+# 버킷 객체 소유권 => 버킷 owner, cloudfront가 로그 업로드 허용
+resource "aws_s3_bucket_ownership_controls" "fe_log" {
+  bucket = aws_s3_bucket.fe_log.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+# AWS log delivery 서비스가 로그를 쓸 수 있도록 acl 설정
+resource "aws_s3_bucket_acl" "fe_log" {
+  # 소유권 설정 먼저 적용
+  depends_on = [aws_s3_bucket_ownership_controls.fe_log]
+
+  bucket = aws_s3_bucket.fe_log.id
+  acl    = "log-delivery-write"
+}

--- a/terraform/modules/s3/outputs.tf
+++ b/terraform/modules/s3/outputs.tf
@@ -20,5 +20,5 @@ output "bucket_regional_domain_name" {
 
 output "log_bucket_domain_name" {
   description = "S3 log bucket domain name"
-  value = aws_s3_bucket.fe_log.bucket_domain_name
+  value       = aws_s3_bucket.fe_log.bucket_domain_name
 }

--- a/terraform/modules/s3/outputs.tf
+++ b/terraform/modules/s3/outputs.tf
@@ -1,0 +1,24 @@
+output "bucket_id" {
+  description = "S3 bucket ID"
+  value       = aws_s3_bucket.fe.id
+}
+
+output "bucket_arn" {
+  description = "S3 bucket ARN"
+  value       = aws_s3_bucket.fe.arn
+}
+
+output "bucket_domain_name" {
+  description = "S3 bucket domain name"
+  value       = aws_s3_bucket.fe.bucket_domain_name
+}
+
+output "bucket_regional_domain_name" {
+  description = "S3 bucket region domain name"
+  value       = aws_s3_bucket.fe.bucket_regional_domain_name
+}
+
+output "log_bucket_domain_name" {
+  description = "S3 log bucket domain name"
+  value = aws_s3_bucket.fe_log.bucket_domain_name
+}

--- a/terraform/modules/s3/variables.tf
+++ b/terraform/modules/s3/variables.tf
@@ -1,0 +1,14 @@
+variable "bucket_name" {
+  default = "S3 Bucket Name"
+  type    = string
+}
+
+variable "prefix" {
+  description = "Prefix for S3 module"
+  type        = string
+}
+
+variable "log_bucket_name" {
+  description = "S3 bucket name for log"
+  type = string
+}

--- a/terraform/modules/s3/variables.tf
+++ b/terraform/modules/s3/variables.tf
@@ -10,5 +10,5 @@ variable "prefix" {
 
 variable "log_bucket_name" {
   description = "S3 bucket name for log"
-  type = string
+  type        = string
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -15,7 +15,7 @@ output "CLOUDFRONT_DISTRIBUTION_ID" {
 
 output "AWS_REGION" {
   description = "GitHub secrets(AWS_REGION) - AWS region"
-  value = var.aws_region
+  value       = var.aws_region
 }
 
 output "web_urls" {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,104 @@
+output "S3_BUCKET_NAME" {
+  description = "GitHub secrets(S3_BUCKET_NAME) - S3 bukcet ID"
+  value       = module.s3.bucket_id
+}
+
+output "AWS_ROLE_ARN" {
+  description = "GitHub secrets(AWS_ROLE_ARN) - Github IAM Role ARN"
+  value       = module.github_oidc.role_arn
+}
+
+output "CLOUDFRONT_DISTRIBUTION_ID" {
+  description = "GitHub secrets(CLOUDFRONT_DISTRIBUTION_ID) - Cloudfront distribution ID"
+  value       = module.cloudfront.distribution_id
+}
+
+output "AWS_REGION" {
+  description = "GitHub secrets(AWS_REGION) - AWS region"
+  value = var.aws_region
+}
+
+output "web_urls" {
+  description = "Frontend access URL"
+  value = [
+    "https://${var.domain_name}",
+    "https://www.${var.domain_name}"
+  ]
+}
+
+# output "cloudfront_distribution_domain" {
+#   description = "CloudFront distribution domain"
+#   value       = module.cloudfront.distribution_domain_name
+# }
+#
+# output "acm_certificate_status" {
+#   description = "ACM certificate status"
+#   value       = module.acm.certificate_status
+# }
+#
+#
+#
+# output "s3_bucket_arn" {
+#   description = "S3 bucket ARN"
+#   value = module.s3.bucket_arn
+# }
+#
+# output "s3_bucket_domain_name" {
+#   description = "S3 bukcet domain name"
+#   value       = module.s3.bucket_domain_name
+# }
+#
+# output "s3_bucket_regional_domain_name" {
+#   description = "S3 bucket region domain name"
+#   value = module.s3.bucket_regional_domain_name
+# }
+#
+# output "s3_fe_log_bucket_domain_name" {
+#   description = "Frontend CloudFront access log S3 bucket"
+#   value = module.s3.log_bucket_domain_name
+# }
+#
+# output "route53_zone_id" {
+#   description = "Route53 hosting zone ID"
+#   value = module.route53.zone_id
+# }
+#
+# output "route53_name_servers" {
+#   description = "Route53 nameserver"
+#   value = module.route53.name_servers
+# }
+#
+# output "github_role_name" {
+#   description = "Github IAM Role name"
+#   value       = module.github_oidc.role_name
+# }
+#
+# output "github_oidc_provider_arn" {
+#   description = "Github OIDC Provider ARN"
+#   value       = module.github_oidc.oidc_provider_arn
+# }
+#
+# output "cf_distribution_arn" {
+#   description = "CloudFront distribution ARN"
+#   value = module.cloudfront.distribution_arn
+# }
+#
+# output "cf_distribution_hosted_zone_id" {
+#   description = "CloudFront distribution hosted zone ID"
+#   value = module.cloudfront.distribution_hosted_zone_id
+# }
+#
+# output "acm_cert_arn" {
+#   description = "ACM certificate ARN"
+#   value       = module.acm.certificate_arn
+# }
+#
+# output "acm_cert_id" {
+#   description = "ACM certificate ID"
+#   value       = module.acm.certificate_id
+# }
+#
+# output "acm_dom_val_opt" {
+#   description = "ACM Domain validation option"
+#   value       = module.acm.domain_validation_options
+# }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,29 @@
+variable "aws_region" {
+  description = "AWS Region"
+  type        = string
+}
+
+variable "prefix" {
+  description = "Prefix"
+  type        = string
+}
+
+variable "domain_name" {
+  description = "Domain name"
+  type        = string
+}
+
+variable "bucket_name" {
+  description = "S3 bucket name"
+  type        = string
+}
+
+variable "github_allowed_repo" {
+  description = "Allowed github repo list (username/repo-name)"
+  type        = list(string)
+}
+
+variable "log_bucket_name" {
+  description = "S3 bucket name for Cloudfront access log"
+  type = string
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -25,5 +25,5 @@ variable "github_allowed_repo" {
 
 variable "log_bucket_name" {
   description = "S3 bucket name for Cloudfront access log"
-  type = string
+  type        = string
 }


### PR DESCRIPTION
**Terraform 추가**
- 주요 리소스
> - S3
> - Route53
> - CloudFront

- GitHub secrets
> - AWS_REGION
> - AWS_ROLE_ARN
> - CLOUDFRONT_DISTRIBUTION_ID
> - S3_BUCKET_NAME
 
- 참고
> - S3 퍼블릭 전면 차단
> - CloudFront origin access control(OAC)통해서만 버킷 내 객체 읽을 수 있도록 s3 버킷 정책 (Cloudfront캐시 계층 경유 요청만 허용) 
> - Cloudfront 생성시 OAC 생성 → OAC ID 를 s3 정책/CloudFront origin 설정에 연결하면 Cloudfornt 만 s3에 접근 가능 (S3에 서명기반 요청)  == oidc 생성 필요
> - OIDC로 GitHub actions에서 s3로 배포 가능 (s3 퍼블릭만 차단 → oidc로 자격 증명)
> - CloudFront(FE)에 접속시 지정된 버킷에 엑세스 기록 로깅

---

**GitHub Actions 추가**
- Workflow (Build step)
`Checkout → Node.js setup → Dependencies install → Build → Upload artifact`
- Workflow (Deploy step)
`Download artifact → Upload to S3 → CloudFront cache reset`